### PR TITLE
Updated the problem that the dll dynamic link library could not be found

### DIFF
--- a/OpenLive-Windows/OpenLive/OpenLive.vcxproj
+++ b/OpenLive-Windows/OpenLive/OpenLive.vcxproj
@@ -117,6 +117,9 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
+    <PostBuildEvent>
+      <Command>copy ..\sdk\dll\*.dll ..\Debug\</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>


### PR DESCRIPTION
解决用户无需手动复制sdk 中的dll 文件到指定文件夹即可运行程序的问题