### PR TITLE
Update the README.md file

### DIFF
--- a/OpenLive-Windows/README.md
+++ b/OpenLive-Windows/README.md
@@ -1,4 +1,4 @@
-# Open Live Windows
+﻿# Open Live Windows
 
 *其他语言版本： [简体中文](README.zh.md)*
 
@@ -32,7 +32,9 @@ Next, download the **Agora Video SDK** from [Agora.io SDK](https://www.agora.io/
 Finally, Open OpenLive.sln with your VC++ 2013(or higher) and build all solution and run.
 
 Note：
-  You may encounter crash when running this demo under debug mode. Please run this demo under release mode.
+  1. After the program is compiled, if the program "xxx\xxx\xxx\Debug\Language\English.dll" cannot be started when running the program, 
+      please select the OpenLive project in the Solution Explorer and right click. In the pop-up menu bar, select "Set as startup project" to solve. Then run the program again.
+  2. You may encounter crash when running this demo under debug mode. Please run this demo under release mode.
   
 ## Developer Environment Requirements
 * VC++ 2013(or higher)

--- a/OpenLive-Windows/README.zh.md
+++ b/OpenLive-Windows/README.zh.md
@@ -1,4 +1,4 @@
-# Open Live Windows
+﻿# Open Live Windows
 
 *Read this in other languages: [English](README.md)*
 
@@ -35,7 +35,9 @@
 最后使用 VC++2013 打开 OpenLive.sln，编译整个解决方案即可运行
 
 Note:
-  本开源项目在 debug 模式下运行可能会出现崩溃，请在 release 模式下运行。
+  1. 程序编译后，在运行程序时如若出现：无法启动程序"C:\Users\Public\Documents\test\Basic-Video-Broadcasting-master\OpenLive-Windows\Debug\Language\English.dll"
+      的错误提示，请在解决方案资源管理器中选中OpenLive 项目，并右击，在弹出的菜单栏中选择 "设为启动项目"，即可解决。之后重新运行程序即可。
+  2. 本开源项目在 debug 模式下运行可能会出现崩溃，请在 release 模式下运行。
 
 ## 运行环境
 * VC++ 2013(或更高版本)

--- a/OpenLive-Windows/README.zh.md
+++ b/OpenLive-Windows/README.zh.md
@@ -35,8 +35,8 @@
 最后使用 VC++2013 打开 OpenLive.sln，编译整个解决方案即可运行
 
 Note:
-  1. 程序编译后，在运行程序时如若出现：无法启动程序"C:\Users\Public\Documents\test\Basic-Video-Broadcasting-master\OpenLive-Windows\Debug\Language\English.dll"
-      的错误提示，请在解决方案资源管理器中选中OpenLive 项目，并右击，在弹出的菜单栏中选择 "设为启动项目"，即可解决。之后重新运行程序即可。
+  1. 程序编译后，在运行程序时如若出现：无法启动程序"xxx\xxx\xxx\Debug\Language\English.dll"的错误提示，
+      请在解决方案资源管理器中选中OpenLive 项目，并右击，在弹出的菜单栏中选择 "设为启动项目"，即可解决。之后重新运行程序即可。
   2. 本开源项目在 debug 模式下运行可能会出现崩溃，请在 release 模式下运行。
 
 ## 运行环境


### PR DESCRIPTION
在readme.md 和 readme.zh.md文件中，增加了对 “无法启动程序xxx\xxx\xxx\Debug\Language\English.dll” 错误的解决方案：即把OpenLive 设为启动项目即可。