### PR TITLE
Fix broken documentation link

### DIFF
--- a/OpenLive-Web/README.md
+++ b/OpenLive-Web/README.md
@@ -29,7 +29,7 @@ To build and run the sample application, get an App ID:
 
 > To ensure communication security, Agora uses tokens (dynamic keys) to authenticate users joining a channel.
 >
-> Temporary tokens are for demonstration and testing purposes only and remain valid for 24 hours. In a production environment, you need to deploy your own server for generating tokens. See [Generate a Token](https://docs.agora.io/en/Interactive Broadcast/token_server)for details.
+> Temporary tokens are for demonstration and testing purposes only and remain valid for 24 hours. In a production environment, you need to deploy your own server for generating tokens. See [Generate a Token](https://docs.agora.io/en/Interactive%20Broadcast/token_server) for details.
 
 ### Install dependencies and integrate the Agora Video SDK
 


### PR DESCRIPTION
Fixing the broken link from the below paragraph

```Temporary tokens are for demonstration and testing purposes only and remain valid for 24 hours. In a production environment, you need to deploy your own server for generating tokens. See [Generate a Token](https://docs.agora.io/en/Interactive Broadcast/token_server)for details.```