### PR TITLE
update agora-rtc-sdk version

### DIFF
--- a/OpenLive-Web/package.json
+++ b/OpenLive-Web/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@material-ui/core": "^4.4.0",
     "@material-ui/icons": "^4.2.1",
-    "agora-rtc-sdk": "3.0.2",
+    "agora-rtc-sdk": "^3.6.10",
     "clsx": "^1.0.4",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",


### PR DESCRIPTION
"agora-rtc-sdk": "3.0.2" called camera failed, update latest 3.6.10, it's okay.